### PR TITLE
workaround for get_tags_in_window bug in GR 3.8.2 and 3.8.3

### DIFF
--- a/python/demod.py
+++ b/python/demod.py
@@ -64,7 +64,7 @@ class demod(gr.sync_block):
             self.straddled_packet = 0
 
         # Get tags from ADS-B Framer block
-        tags = self.get_tags_in_window(0, 0, len(in0), pmt.to_pmt("burst"))
+        tags = self.get_tags_in_range(0, self.nitems_read(0), self.nitems_read(0) + len(in0), pmt.to_pmt("burst"))
 
         for tag in tags:
             # Grab metadata for this tag


### PR DESCRIPTION
Workaround for nasty bug fixed in https://github.com/gnuradio/gnuradio/pull/5166/files it was backported to maint-3.9 but there might be folks with 3.9.2 or 3.9.3 that don't have the backport