### PR TITLE
adapt the receiver example for use with RTL-SDR (RTL2832U) chips or file source and update webserver dependencies for better compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,79 @@
 
+# Fork Notice  
+  
+This repository is a fork of [gr-adsb](https://github.com/mhostetter/gr-adsb).    
+The goal of this fork is to adapt the `adsb_rx.grc` example for use with RTL-SDR (RTL2832U) chips or file source and update dependencies for better compatibility.  
+  
+## Changes in this Fork  
+  
+**Updated GNU Radio Flowgraph**:    
+- Replaced UHD USRP Source with SoapySDR RTL-SDR source (Maintained 2M sample rate and 1.09G center frequency)
+- Added file source version for offline analysis  
+- Added waterfall and time sink displays for signal visualization  
+  
+**Modifications for RTL2832U Compatibility**:    
+- Added SoapySDR API for RTL-SDR hardware access  
+- Added configurable gain control with default 20dB setting
+  
+**Updated Webserver Dependencies**:  
+- Upgraded `socket.io` version to **4.8.1** in `index.html` for v4 support  
+- Added Python virtual environment instructions  
+  
+If you're using an RTL2832U-based SDR, follow the updated setup instructions below.  
+  
+  
+## Installation  
+  
+GNU Radio is a dependency for `gr-adsb`. First, install GNU Radio and its companion tool on your (Linux) system. 
+  
+**Debian/Ubuntu:**  
+  
+```bash  
+sudo apt-get update && sudo apt-get install gnuradio gnuradio-companion
+```  
+  
+**Fedora:**  
+  
+```bash  
+sudo dnf install gnuradio gnuradio-companion  
+```  
+  
+**Arch Linux:**  
+  
+```bash  
+sudo pacman -S gnuradio  
+```  
+  
+After installing GNU Radio, build `gr-adsb` manually from source using the following procedure:  
+  
+```bash  
+git clone https://github.com/iMRUM/gr-adsb.git 
+cd gr-adsb
+mkdir build
+cd build
+cmake ../  # or cmake -DCMAKE_INSTALL_PREFIX=<path_to_install> 
+make  
+sudo make install
+sudo ldconfig 
+  ```  
+  
+### Webserver Python Dependencies:  
+
+If using the built-in updated Google Maps webserver, you'll need to install the following Python packages.  
+NOTE: If using a Python virtual environment, create one and make it aware to the system-wide GNU Radio packages. Here's how to do it:  
+  
+```bash  
+python -m venv .venv --system-site-packages
+source .venv/bin/activate
+pip3 install zmq
+pip3 install flask
+pip3 install flask-socketio
+pip3 install gevent
+pip3 install gevent-websocket  
+```  
+**(end of fork notice)**  
+
+
 # gr-adsb
 
 A GNU Radio out-of-tree (OOT) module to demodulate and decode Automatic Dependent Surveillance Broadcast (ADS-B) messages.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,12 @@ sudo apt-get update && sudo apt-get install gnuradio
   
 ```bash  
 sudo dnf install gnuradio 
-```  
+```
+**Other Linux Distros:**  
 
+```bash  
+sudo {apt,dnf,yay,emerge,…} install gnuradio
+```  
   
 After installing GNU Radio, build `gr-adsb` manually from source using the following procedure:  
   

--- a/README.md
+++ b/README.md
@@ -31,20 +31,15 @@ GNU Radio is a dependency for `gr-adsb`. First, install GNU Radio and its compan
 **Debian/Ubuntu:**  
   
 ```bash  
-sudo apt-get update && sudo apt-get install gnuradio gnuradio-companion
+sudo apt-get update && sudo apt-get install gnuradio
 ```  
   
 **Fedora:**  
   
 ```bash  
-sudo dnf install gnuradio gnuradio-companion  
+sudo dnf install gnuradio 
 ```  
-  
-**Arch Linux:**  
-  
-```bash  
-sudo pacman -S gnuradio  
-```  
+
   
 After installing GNU Radio, build `gr-adsb` manually from source using the following procedure:  
   
@@ -53,7 +48,7 @@ git clone https://github.com/iMRUM/gr-adsb.git
 cd gr-adsb
 mkdir build
 cd build
-cmake ..  # or cmake -DCMAKE_INSTALL_PREFIX=<path_to_install> 
+cmake ..  
 make  
 sudo make install
 sudo ldconfig 
@@ -65,7 +60,7 @@ If using the built-in updated Google Maps webserver, you'll need to install the 
 NOTE: If using a Python virtual environment, create one and make it aware to the system-wide GNU Radio packages. Here's how to do it:  
   
 ```bash  
-python -m venv .venv --system-site-packages
+python3 -m venv .venv --system-site-packages
 source .venv/bin/activate
 pip3 install zmq
 pip3 install flask

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 
 # Fork Notice  
-  
-This repository is a fork of [gr-adsb](https://github.com/mhostetter/gr-adsb).    
+
+This work was done as an assignment for [Prof. Boaz Ben-Moshe](https://www.ariel.ac.il/wp/bmboaz/)'s SDR course at Ariel University.  
+This repository is a fork of [gr-adsb](https://github.com/mhostetter/gr-adsb).  
 The goal of this fork is to adapt the `adsb_rx.grc` example for use with RTL-SDR (RTL2832U) chips or file source and update dependencies for better compatibility.  
+
   
 ## Changes in this Fork  
   
@@ -51,7 +53,7 @@ git clone https://github.com/iMRUM/gr-adsb.git
 cd gr-adsb
 mkdir build
 cd build
-cmake ../  # or cmake -DCMAKE_INSTALL_PREFIX=<path_to_install> 
+cmake ..  # or cmake -DCMAKE_INSTALL_PREFIX=<path_to_install> 
 make  
 sudo make install
 sudo ldconfig 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,22 @@ The goal of this fork is to adapt the `adsb_rx.grc` example for use with RTL-SDR
   
 ## Changes in this Fork  
   
-**Updated GNU Radio Flowgraph**:    
-- Replaced UHD USRP Source with SoapySDR RTL-SDR source (Maintained 2M sample rate and 1.09G center frequency)
-- Added file source version for offline analysis  
-- Added waterfall and time sink displays for signal visualization  
+### GNU Radio Flowgraph Updates:    
+#### AU_adsb_rx_from_SoapyRTLSDR.grc:
+
+- Replaced the **UHD USRP Source** with a **SoapySDR-based RTL-SDR source**  
+  *(Maintained a 2 MS/s sample rate and 1.09 GHz center frequency)*
+- Enabled support for **RTL2832U** devices using the **SoapySDR API**
+- Added **configurable gain control** *(default: 20 dB)*
+- Introduced **waterfall** and **time sink** visualizations for improved real-time signal monitoring
+
+#### AU_adsb_rx_from_file.grc:
+
+- Replaced **live source** with a **file source** to allow offline signal analysis
+- Retained signal visualization using **waterfall** and **time sinks**
   
-**Modifications for RTL2832U Compatibility**:    
-- Added SoapySDR API for RTL-SDR hardware access  
-- Added configurable gain control with default 20dB setting
   
-**Updated Webserver Dependencies**:  
+### Webserver Updates:  
 - Upgraded `socket.io` version to **4.8.1** in `index.html` for v4 support  
 - Added Python virtual environment instructions  
   

--- a/README.md
+++ b/README.md
@@ -60,17 +60,20 @@ sudo ldconfig
   
 ### Webserver Python Dependencies:  
 
-If using the built-in updated Google Maps webserver, you'll need to install the following Python packages.  
 NOTE: If using a Python virtual environment, create one and make it aware to the system-wide GNU Radio packages. Here's how to do it:  
   
 ```bash  
 python3 -m venv .venv --system-site-packages
-source .venv/bin/activate
-pip3 install zmq
-pip3 install flask
-pip3 install flask-socketio
-pip3 install gevent
-pip3 install gevent-websocket  
+source .venv/bin/activate  
+```   
+If using the built-in updated Google Maps webserver, you'll need to install the following Python packages:
+  
+```bash  
+pip3 install zmq  
+pip3 install flask  
+pip3 install flask-socketio  
+pip3 install gevent  
+pip3 install gevent-websocket    
 ```  
 **(end of fork notice)**  
 

--- a/examples/AU_adsb_rx_from_SoapyRTLSDR.grc
+++ b/examples/AU_adsb_rx_from_SoapyRTLSDR.grc
@@ -142,21 +142,6 @@ blocks:
     coordinate: [1096, 608.0]
     rotation: 0
     state: disabled
-- name: blocks_message_debug_0
-  id: blocks_message_debug
-  parameters:
-    affinity: ''
-    alias: ''
-    comment: ''
-    en_uvec: 'True'
-    log_level: info
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [520, 604.0]
-    rotation: 0
-    state: enabled
 - name: qtgui_time_sink_x_1
   id: qtgui_time_sink_x
   parameters:
@@ -355,24 +340,6 @@ blocks:
     coordinate: [1528, 52.0]
     rotation: 0
     state: enabled
-- name: zeromq_pull_msg_source_1
-  id: zeromq_pull_msg_source
-  parameters:
-    address: tcp://127.0.0.1:9034
-    affinity: ''
-    alias: ''
-    bind: 'False'
-    comment: ''
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    timeout: '100'
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [56, 604.0]
-    rotation: 0
-    state: enabled
 
 connections:
 - [adsb_decoder_0, decoded, zeromq_pub_msg_sink_0, in]
@@ -383,7 +350,6 @@ connections:
 - [soapy_rtlsdr_source_0, '0', blocks_complex_to_mag_squared_0, '0']
 - [soapy_rtlsdr_source_0, '0', blocks_file_sink_0, '0']
 - [soapy_rtlsdr_source_0, '0', qtgui_waterfall_sink_x_0, '0']
-- [zeromq_pull_msg_source_1, out, blocks_message_debug_0, print]
 
 metadata:
   file_format: 1

--- a/examples/AU_adsb_rx_from_SoapyRTLSDR.grc
+++ b/examples/AU_adsb_rx_from_SoapyRTLSDR.grc
@@ -1,0 +1,390 @@
+options:
+  parameters:
+    author: shoam&iMRUM
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: AU_adsb_rx_from_SoapyRTLSDR
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: ADS-B Reciever
+    window_size: (1000,1000)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [24, 12.0]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: freq
+  id: variable
+  parameters:
+    comment: ''
+    value: 1090e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [136, 12.0]
+    rotation: 0
+    state: enabled
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '2000000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 12.0]
+    rotation: 0
+    state: enabled
+- name: adsb_decoder_0
+  id: adsb_decoder
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    error_corr: '"None"'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    msg_filter: '"Extended Squitter Only"'
+    print_level: '"Verbose"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1024, 48.0]
+    rotation: 0
+    state: enabled
+- name: adsb_demod_0
+  id: adsb_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    fs: 2e6
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [864, 232.0]
+    rotation: 0
+    state: enabled
+- name: adsb_framer_0
+  id: adsb_framer
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    fs: 2e6
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    threshold: '0.01'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [496, 192.0]
+    rotation: 0
+    state: enabled
+- name: blocks_complex_to_mag_squared_0
+  id: blocks_complex_to_mag_squared
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [352, 300.0]
+    rotation: 0
+    state: enabled
+- name: blocks_file_sink_0
+  id: blocks_file_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    append: 'False'
+    comment: ''
+    file: path/to/your/adsb/recording
+    type: complex
+    unbuffered: 'False'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1096, 608.0]
+    rotation: 0
+    state: disabled
+- name: blocks_message_debug_0
+  id: blocks_message_debug
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    en_uvec: 'True'
+    log_level: info
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [520, 604.0]
+    rotation: 0
+    state: enabled
+- name: qtgui_time_sink_x_1
+  id: qtgui_time_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    autoscale: 'True'
+    axislabels: 'True'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
+    comment: ''
+    ctrlpanel: 'False'
+    entags: 'True'
+    grid: 'True'
+    gui_hint: ''
+    label1: Signal 1
+    label10: Signal 10
+    label2: Signal 2
+    label3: Signal 3
+    label4: Signal 4
+    label5: Signal 5
+    label6: Signal 6
+    label7: Signal 7
+    label8: Signal 8
+    label9: Signal 9
+    legend: 'True'
+    marker1: '-1'
+    marker10: '-1'
+    marker2: '-1'
+    marker3: '-1'
+    marker4: '-1'
+    marker5: '-1'
+    marker6: '-1'
+    marker7: '-1'
+    marker8: '-1'
+    marker9: '-1'
+    name: '""'
+    nconnections: '1'
+    size: '1024'
+    srate: samp_rate
+    stemplot: 'False'
+    style1: '1'
+    style10: '1'
+    style2: '1'
+    style3: '1'
+    style4: '1'
+    style5: '1'
+    style6: '1'
+    style7: '1'
+    style8: '1'
+    style9: '1'
+    tr_chan: '0'
+    tr_delay: '0'
+    tr_level: '0.0'
+    tr_mode: qtgui.TRIG_MODE_FREE
+    tr_slope: qtgui.TRIG_SLOPE_POS
+    tr_tag: '""'
+    type: float
+    update_time: '0.10'
+    width1: '1'
+    width10: '1'
+    width2: '1'
+    width3: '1'
+    width4: '1'
+    width5: '1'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    ylabel: Signal Strength
+    ymax: '1'
+    ymin: '-1'
+    yunit: db
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1104, 416.0]
+    rotation: 0
+    state: true
+- name: qtgui_waterfall_sink_x_0
+  id: qtgui_waterfall_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    axislabels: 'True'
+    bw: samp_rate
+    color1: '0'
+    color10: '0'
+    color2: '0'
+    color3: '0'
+    color4: '0'
+    color5: '0'
+    color6: '0'
+    color7: '0'
+    color8: '0'
+    color9: '0'
+    comment: ''
+    fc: '0'
+    fftsize: '1024'
+    freqhalf: 'True'
+    grid: 'False'
+    gui_hint: ''
+    int_max: '10'
+    int_min: '-140'
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    legend: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: '""'
+    nconnections: '1'
+    showports: 'False'
+    type: complex
+    update_time: '0.10'
+    wintype: window.WIN_BLACKMAN_hARRIS
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [328, 40.0]
+    rotation: 0
+    state: enabled
+- name: soapy_rtlsdr_source_0
+  id: soapy_rtlsdr_source
+  parameters:
+    affinity: ''
+    agc: 'False'
+    alias: ''
+    bias: 'False'
+    bufflen: '16384'
+    center_freq: freq
+    comment: ''
+    dev_args: ''
+    freq_correction: '0'
+    gain: '20'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samp_rate: samp_rate
+    type: fc32
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [40, 288.0]
+    rotation: 0
+    state: enabled
+- name: zeromq_pub_msg_sink_0
+  id: zeromq_pub_msg_sink
+  parameters:
+    address: tcp://127.0.0.1:9034
+    affinity: ''
+    alias: ''
+    bind: 'True'
+    comment: ''
+    timeout: '100'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1528, 52.0]
+    rotation: 0
+    state: enabled
+- name: zeromq_pull_msg_source_1
+  id: zeromq_pull_msg_source
+  parameters:
+    address: tcp://127.0.0.1:9034
+    affinity: ''
+    alias: ''
+    bind: 'False'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    timeout: '100'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [56, 604.0]
+    rotation: 0
+    state: enabled
+
+connections:
+- [adsb_decoder_0, decoded, zeromq_pub_msg_sink_0, in]
+- [adsb_demod_0, '0', qtgui_time_sink_x_1, '0']
+- [adsb_demod_0, demodulated, adsb_decoder_0, demodulated]
+- [adsb_framer_0, '0', adsb_demod_0, '0']
+- [blocks_complex_to_mag_squared_0, '0', adsb_framer_0, '0']
+- [soapy_rtlsdr_source_0, '0', blocks_complex_to_mag_squared_0, '0']
+- [soapy_rtlsdr_source_0, '0', blocks_file_sink_0, '0']
+- [soapy_rtlsdr_source_0, '0', qtgui_waterfall_sink_x_0, '0']
+- [zeromq_pull_msg_source_1, out, blocks_message_debug_0, print]
+
+metadata:
+  file_format: 1
+  grc_version: 3.10.9.2

--- a/examples/AU_adsb_rx_from_SoapyRTLSDR.py
+++ b/examples/AU_adsb_rx_from_SoapyRTLSDR.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#
+# SPDX-License-Identifier: GPL-3.0
+#
+# GNU Radio Python Flow Graph
+# Title: ADS-B Reciever
+# Author: shoam&iMRUM
+# GNU Radio version: 3.10.9.2
+
+from PyQt5 import Qt
+from gnuradio import qtgui
+from gnuradio import blocks
+from gnuradio import blocks, gr
+from gnuradio import gr
+from gnuradio.filter import firdes
+from gnuradio.fft import window
+import sys
+import signal
+from PyQt5 import Qt
+from argparse import ArgumentParser
+from gnuradio.eng_arg import eng_float, intx
+from gnuradio import eng_notation
+from gnuradio import soapy
+from gnuradio import zeromq
+import gnuradio.adsb as adsb
+import sip
+
+
+
+class AU_adsb_rx_from_SoapyRTLSDR(gr.top_block, Qt.QWidget):
+
+    def __init__(self):
+        gr.top_block.__init__(self, "ADS-B Reciever", catch_exceptions=True)
+        Qt.QWidget.__init__(self)
+        self.setWindowTitle("ADS-B Reciever")
+        qtgui.util.check_set_qss()
+        try:
+            self.setWindowIcon(Qt.QIcon.fromTheme('gnuradio-grc'))
+        except BaseException as exc:
+            print(f"Qt GUI: Could not set Icon: {str(exc)}", file=sys.stderr)
+        self.top_scroll_layout = Qt.QVBoxLayout()
+        self.setLayout(self.top_scroll_layout)
+        self.top_scroll = Qt.QScrollArea()
+        self.top_scroll.setFrameStyle(Qt.QFrame.NoFrame)
+        self.top_scroll_layout.addWidget(self.top_scroll)
+        self.top_scroll.setWidgetResizable(True)
+        self.top_widget = Qt.QWidget()
+        self.top_scroll.setWidget(self.top_widget)
+        self.top_layout = Qt.QVBoxLayout(self.top_widget)
+        self.top_grid_layout = Qt.QGridLayout()
+        self.top_layout.addLayout(self.top_grid_layout)
+
+        self.settings = Qt.QSettings("GNU Radio", "AU_adsb_rx_from_SoapyRTLSDR")
+
+        try:
+            geometry = self.settings.value("geometry")
+            if geometry:
+                self.restoreGeometry(geometry)
+        except BaseException as exc:
+            print(f"Qt GUI: Could not restore geometry: {str(exc)}", file=sys.stderr)
+
+        ##################################################
+        # Variables
+        ##################################################
+        self.samp_rate = samp_rate = 2000000
+        self.freq = freq = 1090e6
+
+        ##################################################
+        # Blocks
+        ##################################################
+
+        self.zeromq_pull_msg_source_1 = zeromq.pull_msg_source('tcp://127.0.0.1:9034', 100, False)
+        self.zeromq_pub_msg_sink_0 = zeromq.pub_msg_sink('tcp://127.0.0.1:9034', 100, True)
+        self.soapy_rtlsdr_source_0 = None
+        dev = 'driver=rtlsdr'
+        stream_args = 'bufflen=16384'
+        tune_args = ['']
+        settings = ['']
+
+        def _set_soapy_rtlsdr_source_0_gain_mode(channel, agc):
+            self.soapy_rtlsdr_source_0.set_gain_mode(channel, agc)
+            if not agc:
+                  self.soapy_rtlsdr_source_0.set_gain(channel, self._soapy_rtlsdr_source_0_gain_value)
+        self.set_soapy_rtlsdr_source_0_gain_mode = _set_soapy_rtlsdr_source_0_gain_mode
+
+        def _set_soapy_rtlsdr_source_0_gain(channel, name, gain):
+            self._soapy_rtlsdr_source_0_gain_value = gain
+            if not self.soapy_rtlsdr_source_0.get_gain_mode(channel):
+                self.soapy_rtlsdr_source_0.set_gain(channel, gain)
+        self.set_soapy_rtlsdr_source_0_gain = _set_soapy_rtlsdr_source_0_gain
+
+        def _set_soapy_rtlsdr_source_0_bias(bias):
+            if 'biastee' in self._soapy_rtlsdr_source_0_setting_keys:
+                self.soapy_rtlsdr_source_0.write_setting('biastee', bias)
+        self.set_soapy_rtlsdr_source_0_bias = _set_soapy_rtlsdr_source_0_bias
+
+        self.soapy_rtlsdr_source_0 = soapy.source(dev, "fc32", 1, '',
+                                  stream_args, tune_args, settings)
+
+        self._soapy_rtlsdr_source_0_setting_keys = [a.key for a in self.soapy_rtlsdr_source_0.get_setting_info()]
+
+        self.soapy_rtlsdr_source_0.set_sample_rate(0, samp_rate)
+        self.soapy_rtlsdr_source_0.set_frequency(0, freq)
+        self.soapy_rtlsdr_source_0.set_frequency_correction(0, 0)
+        self.set_soapy_rtlsdr_source_0_bias(bool(False))
+        self._soapy_rtlsdr_source_0_gain_value = 20
+        self.set_soapy_rtlsdr_source_0_gain_mode(0, bool(False))
+        self.set_soapy_rtlsdr_source_0_gain(0, 'TUNER', 20)
+        self.qtgui_waterfall_sink_x_0 = qtgui.waterfall_sink_c(
+            1024, #size
+            window.WIN_BLACKMAN_hARRIS, #wintype
+            0, #fc
+            samp_rate, #bw
+            "", #name
+            1, #number of inputs
+            None # parent
+        )
+        self.qtgui_waterfall_sink_x_0.set_update_time(0.10)
+        self.qtgui_waterfall_sink_x_0.enable_grid(False)
+        self.qtgui_waterfall_sink_x_0.enable_axis_labels(True)
+
+
+
+        labels = ['', '', '', '', '',
+                  '', '', '', '', '']
+        colors = [0, 0, 0, 0, 0,
+                  0, 0, 0, 0, 0]
+        alphas = [1.0, 1.0, 1.0, 1.0, 1.0,
+                  1.0, 1.0, 1.0, 1.0, 1.0]
+
+        for i in range(1):
+            if len(labels[i]) == 0:
+                self.qtgui_waterfall_sink_x_0.set_line_label(i, "Data {0}".format(i))
+            else:
+                self.qtgui_waterfall_sink_x_0.set_line_label(i, labels[i])
+            self.qtgui_waterfall_sink_x_0.set_color_map(i, colors[i])
+            self.qtgui_waterfall_sink_x_0.set_line_alpha(i, alphas[i])
+
+        self.qtgui_waterfall_sink_x_0.set_intensity_range(-140, 10)
+
+        self._qtgui_waterfall_sink_x_0_win = sip.wrapinstance(self.qtgui_waterfall_sink_x_0.qwidget(), Qt.QWidget)
+
+        self.top_layout.addWidget(self._qtgui_waterfall_sink_x_0_win)
+        self.qtgui_time_sink_x_1 = qtgui.time_sink_f(
+            1024, #size
+            samp_rate, #samp_rate
+            "", #name
+            1, #number of inputs
+            None # parent
+        )
+        self.qtgui_time_sink_x_1.set_update_time(0.10)
+        self.qtgui_time_sink_x_1.set_y_axis(-1, 1)
+
+        self.qtgui_time_sink_x_1.set_y_label('Signal Strength', 'db')
+
+        self.qtgui_time_sink_x_1.enable_tags(True)
+        self.qtgui_time_sink_x_1.set_trigger_mode(qtgui.TRIG_MODE_FREE, qtgui.TRIG_SLOPE_POS, 0.0, 0, 0, "")
+        self.qtgui_time_sink_x_1.enable_autoscale(True)
+        self.qtgui_time_sink_x_1.enable_grid(True)
+        self.qtgui_time_sink_x_1.enable_axis_labels(True)
+        self.qtgui_time_sink_x_1.enable_control_panel(False)
+        self.qtgui_time_sink_x_1.enable_stem_plot(False)
+
+
+        labels = ['Signal 1', 'Signal 2', 'Signal 3', 'Signal 4', 'Signal 5',
+            'Signal 6', 'Signal 7', 'Signal 8', 'Signal 9', 'Signal 10']
+        widths = [1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1]
+        colors = ['blue', 'red', 'green', 'black', 'cyan',
+            'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+        alphas = [1.0, 1.0, 1.0, 1.0, 1.0,
+            1.0, 1.0, 1.0, 1.0, 1.0]
+        styles = [1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1]
+        markers = [-1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1]
+
+
+        for i in range(1):
+            if len(labels[i]) == 0:
+                self.qtgui_time_sink_x_1.set_line_label(i, "Data {0}".format(i))
+            else:
+                self.qtgui_time_sink_x_1.set_line_label(i, labels[i])
+            self.qtgui_time_sink_x_1.set_line_width(i, widths[i])
+            self.qtgui_time_sink_x_1.set_line_color(i, colors[i])
+            self.qtgui_time_sink_x_1.set_line_style(i, styles[i])
+            self.qtgui_time_sink_x_1.set_line_marker(i, markers[i])
+            self.qtgui_time_sink_x_1.set_line_alpha(i, alphas[i])
+
+        self._qtgui_time_sink_x_1_win = sip.wrapinstance(self.qtgui_time_sink_x_1.qwidget(), Qt.QWidget)
+        self.top_layout.addWidget(self._qtgui_time_sink_x_1_win)
+        self.blocks_message_debug_0 = blocks.message_debug(True, gr.log_levels.info)
+        self.blocks_complex_to_mag_squared_0 = blocks.complex_to_mag_squared(1)
+        self.adsb_framer_0 = adsb.framer(2e6, 0.01)
+        self.adsb_demod_0 = adsb.demod(2e6)
+        self.adsb_decoder_0 = adsb.decoder("Extended Squitter Only", "None", "Verbose")
+
+
+        ##################################################
+        # Connections
+        ##################################################
+        self.msg_connect((self.adsb_decoder_0, 'decoded'), (self.zeromq_pub_msg_sink_0, 'in'))
+        self.msg_connect((self.adsb_demod_0, 'demodulated'), (self.adsb_decoder_0, 'demodulated'))
+        self.msg_connect((self.zeromq_pull_msg_source_1, 'out'), (self.blocks_message_debug_0, 'print'))
+        self.connect((self.adsb_demod_0, 0), (self.qtgui_time_sink_x_1, 0))
+        self.connect((self.adsb_framer_0, 0), (self.adsb_demod_0, 0))
+        self.connect((self.blocks_complex_to_mag_squared_0, 0), (self.adsb_framer_0, 0))
+        self.connect((self.soapy_rtlsdr_source_0, 0), (self.blocks_complex_to_mag_squared_0, 0))
+        self.connect((self.soapy_rtlsdr_source_0, 0), (self.qtgui_waterfall_sink_x_0, 0))
+
+
+    def closeEvent(self, event):
+        self.settings = Qt.QSettings("GNU Radio", "AU_adsb_rx_from_SoapyRTLSDR")
+        self.settings.setValue("geometry", self.saveGeometry())
+        self.stop()
+        self.wait()
+
+        event.accept()
+
+    def get_samp_rate(self):
+        return self.samp_rate
+
+    def set_samp_rate(self, samp_rate):
+        self.samp_rate = samp_rate
+        self.qtgui_time_sink_x_1.set_samp_rate(self.samp_rate)
+        self.qtgui_waterfall_sink_x_0.set_frequency_range(0, self.samp_rate)
+        self.soapy_rtlsdr_source_0.set_sample_rate(0, self.samp_rate)
+
+    def get_freq(self):
+        return self.freq
+
+    def set_freq(self, freq):
+        self.freq = freq
+        self.soapy_rtlsdr_source_0.set_frequency(0, self.freq)
+
+
+
+
+def main(top_block_cls=AU_adsb_rx_from_SoapyRTLSDR, options=None):
+
+    qapp = Qt.QApplication(sys.argv)
+
+    tb = top_block_cls()
+
+    tb.start()
+
+    tb.show()
+
+    def sig_handler(sig=None, frame=None):
+        tb.stop()
+        tb.wait()
+
+        Qt.QApplication.quit()
+
+    signal.signal(signal.SIGINT, sig_handler)
+    signal.signal(signal.SIGTERM, sig_handler)
+
+    timer = Qt.QTimer()
+    timer.start(500)
+    timer.timeout.connect(lambda: None)
+
+    qapp.exec_()
+
+if __name__ == '__main__':
+    main()

--- a/examples/AU_adsb_rx_from_SoapyRTLSDR.py
+++ b/examples/AU_adsb_rx_from_SoapyRTLSDR.py
@@ -12,7 +12,6 @@
 from PyQt5 import Qt
 from gnuradio import qtgui
 from gnuradio import blocks
-from gnuradio import blocks, gr
 from gnuradio import gr
 from gnuradio.filter import firdes
 from gnuradio.fft import window
@@ -71,7 +70,6 @@ class AU_adsb_rx_from_SoapyRTLSDR(gr.top_block, Qt.QWidget):
         # Blocks
         ##################################################
 
-        self.zeromq_pull_msg_source_1 = zeromq.pull_msg_source('tcp://127.0.0.1:9034', 100, False)
         self.zeromq_pub_msg_sink_0 = zeromq.pub_msg_sink('tcp://127.0.0.1:9034', 100, True)
         self.soapy_rtlsdr_source_0 = None
         dev = 'driver=rtlsdr'
@@ -191,7 +189,6 @@ class AU_adsb_rx_from_SoapyRTLSDR(gr.top_block, Qt.QWidget):
 
         self._qtgui_time_sink_x_1_win = sip.wrapinstance(self.qtgui_time_sink_x_1.qwidget(), Qt.QWidget)
         self.top_layout.addWidget(self._qtgui_time_sink_x_1_win)
-        self.blocks_message_debug_0 = blocks.message_debug(True, gr.log_levels.info)
         self.blocks_complex_to_mag_squared_0 = blocks.complex_to_mag_squared(1)
         self.adsb_framer_0 = adsb.framer(2e6, 0.01)
         self.adsb_demod_0 = adsb.demod(2e6)
@@ -203,7 +200,6 @@ class AU_adsb_rx_from_SoapyRTLSDR(gr.top_block, Qt.QWidget):
         ##################################################
         self.msg_connect((self.adsb_decoder_0, 'decoded'), (self.zeromq_pub_msg_sink_0, 'in'))
         self.msg_connect((self.adsb_demod_0, 'demodulated'), (self.adsb_decoder_0, 'demodulated'))
-        self.msg_connect((self.zeromq_pull_msg_source_1, 'out'), (self.blocks_message_debug_0, 'print'))
         self.connect((self.adsb_demod_0, 0), (self.qtgui_time_sink_x_1, 0))
         self.connect((self.adsb_framer_0, 0), (self.adsb_demod_0, 0))
         self.connect((self.blocks_complex_to_mag_squared_0, 0), (self.adsb_framer_0, 0))

--- a/examples/AU_adsb_rx_from_file.grc
+++ b/examples/AU_adsb_rx_from_file.grc
@@ -1,0 +1,391 @@
+options:
+  parameters:
+    author: shoam&iMRUM
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: AU_adsb_rx_from_file
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: ADS-B Signal Analyzer
+    window_size: (1000,1000)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: freq
+  id: variable
+  parameters:
+    comment: ''
+    value: 1090e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 20.0]
+    rotation: 0
+    state: enabled
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '2000000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [128, 20.0]
+    rotation: 0
+    state: enabled
+- name: adsb_decoder_0
+  id: adsb_decoder
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    error_corr: '"None"'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    msg_filter: '"Extended Squitter Only"'
+    print_level: '"Verbose"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1184, 208.0]
+    rotation: 0
+    state: enabled
+- name: adsb_demod_0
+  id: adsb_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    fs: 2e6
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [768, 192.0]
+    rotation: 0
+    state: enabled
+- name: adsb_framer_0
+  id: adsb_framer
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    fs: 2e6
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    threshold: '0.01'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [600, 44.0]
+    rotation: 0
+    state: enabled
+- name: blocks_complex_to_mag_squared_0
+  id: blocks_complex_to_mag_squared
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [568, 292.0]
+    rotation: 0
+    state: enabled
+- name: blocks_file_source_0
+  id: blocks_file_source
+  parameters:
+    affinity: ''
+    alias: ''
+    begin_tag: pmt.PMT_NIL
+    comment: ''
+    file: path/to/your/adsb/recording
+    length: '0'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    offset: 200*samp_rate
+    repeat: 'True'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 208.0]
+    rotation: 0
+    state: enabled
+- name: blocks_message_debug_0
+  id: blocks_message_debug
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    en_uvec: 'True'
+    log_level: info
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [448, 732.0]
+    rotation: 0
+    state: enabled
+- name: blocks_throttle2_0
+  id: blocks_throttle2
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    limit: auto
+    maximum: '0.1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [264, 100.0]
+    rotation: 0
+    state: enabled
+- name: qtgui_time_sink_x_1
+  id: qtgui_time_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    autoscale: 'True'
+    axislabels: 'True'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
+    comment: ''
+    ctrlpanel: 'False'
+    entags: 'True'
+    grid: 'True'
+    gui_hint: ''
+    label1: Signal 1
+    label10: Signal 10
+    label2: Signal 2
+    label3: Signal 3
+    label4: Signal 4
+    label5: Signal 5
+    label6: Signal 6
+    label7: Signal 7
+    label8: Signal 8
+    label9: Signal 9
+    legend: 'True'
+    marker1: '-1'
+    marker10: '-1'
+    marker2: '-1'
+    marker3: '-1'
+    marker4: '-1'
+    marker5: '-1'
+    marker6: '-1'
+    marker7: '-1'
+    marker8: '-1'
+    marker9: '-1'
+    name: '""'
+    nconnections: '1'
+    size: '1024'
+    srate: samp_rate
+    stemplot: 'False'
+    style1: '1'
+    style10: '1'
+    style2: '1'
+    style3: '1'
+    style4: '1'
+    style5: '1'
+    style6: '1'
+    style7: '1'
+    style8: '1'
+    style9: '1'
+    tr_chan: '0'
+    tr_delay: '0'
+    tr_level: '0.0'
+    tr_mode: qtgui.TRIG_MODE_FREE
+    tr_slope: qtgui.TRIG_SLOPE_POS
+    tr_tag: '""'
+    type: float
+    update_time: '0.10'
+    width1: '1'
+    width10: '1'
+    width2: '1'
+    width3: '1'
+    width4: '1'
+    width5: '1'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    ylabel: Signal Strength
+    ymax: '1'
+    ymin: '-1'
+    yunit: db
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [992, 400.0]
+    rotation: 0
+    state: true
+- name: qtgui_waterfall_sink_x_0
+  id: qtgui_waterfall_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    axislabels: 'True'
+    bw: samp_rate
+    color1: '0'
+    color10: '0'
+    color2: '0'
+    color3: '0'
+    color4: '0'
+    color5: '0'
+    color6: '0'
+    color7: '0'
+    color8: '0'
+    color9: '0'
+    comment: ''
+    fc: '0'
+    fftsize: '1024'
+    freqhalf: 'True'
+    grid: 'False'
+    gui_hint: ''
+    int_max: '10'
+    int_min: '-140'
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    legend: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: '""'
+    nconnections: '1'
+    showports: 'False'
+    type: complex
+    update_time: '0.10'
+    wintype: window.WIN_BLACKMAN_hARRIS
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [384, 352.0]
+    rotation: 0
+    state: enabled
+- name: zeromq_pub_msg_sink_0
+  id: zeromq_pub_msg_sink
+  parameters:
+    address: tcp://127.0.0.1:9034
+    affinity: ''
+    alias: ''
+    bind: 'True'
+    comment: ''
+    timeout: '100'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1576, 52.0]
+    rotation: 0
+    state: enabled
+- name: zeromq_pull_msg_source_1
+  id: zeromq_pull_msg_source
+  parameters:
+    address: tcp://127.0.0.1:9034
+    affinity: ''
+    alias: ''
+    bind: 'False'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    timeout: '100'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [32, 732.0]
+    rotation: 0
+    state: enabled
+
+connections:
+- [adsb_decoder_0, decoded, zeromq_pub_msg_sink_0, in]
+- [adsb_demod_0, '0', qtgui_time_sink_x_1, '0']
+- [adsb_demod_0, demodulated, adsb_decoder_0, demodulated]
+- [adsb_framer_0, '0', adsb_demod_0, '0']
+- [blocks_complex_to_mag_squared_0, '0', adsb_framer_0, '0']
+- [blocks_file_source_0, '0', blocks_throttle2_0, '0']
+- [blocks_throttle2_0, '0', blocks_complex_to_mag_squared_0, '0']
+- [blocks_throttle2_0, '0', qtgui_waterfall_sink_x_0, '0']
+- [zeromq_pull_msg_source_1, out, blocks_message_debug_0, print]
+
+metadata:
+  file_format: 1
+  grc_version: 3.10.9.2

--- a/examples/AU_adsb_rx_from_file.grc
+++ b/examples/AU_adsb_rx_from_file.grc
@@ -135,7 +135,7 @@ blocks:
     length: '0'
     maxoutbuf: '0'
     minoutbuf: '0'
-    offset: 200*samp_rate
+    offset: '0'
     repeat: 'True'
     type: complex
     vlen: '1'

--- a/examples/AU_adsb_rx_from_file.grc
+++ b/examples/AU_adsb_rx_from_file.grc
@@ -146,21 +146,6 @@ blocks:
     coordinate: [16, 208.0]
     rotation: 0
     state: enabled
-- name: blocks_message_debug_0
-  id: blocks_message_debug
-  parameters:
-    affinity: ''
-    alias: ''
-    comment: ''
-    en_uvec: 'True'
-    log_level: info
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [448, 732.0]
-    rotation: 0
-    state: enabled
 - name: blocks_throttle2_0
   id: blocks_throttle2
   parameters:
@@ -356,24 +341,6 @@ blocks:
     coordinate: [1576, 52.0]
     rotation: 0
     state: enabled
-- name: zeromq_pull_msg_source_1
-  id: zeromq_pull_msg_source
-  parameters:
-    address: tcp://127.0.0.1:9034
-    affinity: ''
-    alias: ''
-    bind: 'False'
-    comment: ''
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    timeout: '100'
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [32, 732.0]
-    rotation: 0
-    state: enabled
 
 connections:
 - [adsb_decoder_0, decoded, zeromq_pub_msg_sink_0, in]
@@ -384,7 +351,6 @@ connections:
 - [blocks_file_source_0, '0', blocks_throttle2_0, '0']
 - [blocks_throttle2_0, '0', blocks_complex_to_mag_squared_0, '0']
 - [blocks_throttle2_0, '0', qtgui_waterfall_sink_x_0, '0']
-- [zeromq_pull_msg_source_1, out, blocks_message_debug_0, print]
 
 metadata:
   file_format: 1

--- a/examples/AU_adsb_rx_from_file.py
+++ b/examples/AU_adsb_rx_from_file.py
@@ -13,7 +13,6 @@ from PyQt5 import Qt
 from gnuradio import qtgui
 from gnuradio import blocks
 import pmt
-from gnuradio import blocks, gr
 from gnuradio import gr
 from gnuradio.filter import firdes
 from gnuradio.fft import window
@@ -71,7 +70,6 @@ class AU_adsb_rx_from_file(gr.top_block, Qt.QWidget):
         # Blocks
         ##################################################
 
-        self.zeromq_pull_msg_source_1 = zeromq.pull_msg_source('tcp://127.0.0.1:9034', 100, False)
         self.zeromq_pub_msg_sink_0 = zeromq.pub_msg_sink('tcp://127.0.0.1:9034', 100, True)
         self.qtgui_waterfall_sink_x_0 = qtgui.waterfall_sink_c(
             1024, #size
@@ -157,7 +155,6 @@ class AU_adsb_rx_from_file(gr.top_block, Qt.QWidget):
         self._qtgui_time_sink_x_1_win = sip.wrapinstance(self.qtgui_time_sink_x_1.qwidget(), Qt.QWidget)
         self.top_layout.addWidget(self._qtgui_time_sink_x_1_win)
         self.blocks_throttle2_0 = blocks.throttle( gr.sizeof_gr_complex*1, samp_rate, True, 0 if "auto" == "auto" else max( int(float(0.1) * samp_rate) if "auto" == "time" else int(0.1), 1) )
-        self.blocks_message_debug_0 = blocks.message_debug(True, gr.log_levels.info)
         self.blocks_file_source_0 = blocks.file_source(gr.sizeof_gr_complex*1, 'path/to/your/adsb/recording', True, (200*samp_rate), 0)
         self.blocks_file_source_0.set_begin_tag(pmt.PMT_NIL)
         self.blocks_complex_to_mag_squared_0 = blocks.complex_to_mag_squared(1)
@@ -171,7 +168,6 @@ class AU_adsb_rx_from_file(gr.top_block, Qt.QWidget):
         ##################################################
         self.msg_connect((self.adsb_decoder_0, 'decoded'), (self.zeromq_pub_msg_sink_0, 'in'))
         self.msg_connect((self.adsb_demod_0, 'demodulated'), (self.adsb_decoder_0, 'demodulated'))
-        self.msg_connect((self.zeromq_pull_msg_source_1, 'out'), (self.blocks_message_debug_0, 'print'))
         self.connect((self.adsb_demod_0, 0), (self.qtgui_time_sink_x_1, 0))
         self.connect((self.adsb_framer_0, 0), (self.adsb_demod_0, 0))
         self.connect((self.blocks_complex_to_mag_squared_0, 0), (self.adsb_framer_0, 0))

--- a/examples/AU_adsb_rx_from_file.py
+++ b/examples/AU_adsb_rx_from_file.py
@@ -155,7 +155,7 @@ class AU_adsb_rx_from_file(gr.top_block, Qt.QWidget):
         self._qtgui_time_sink_x_1_win = sip.wrapinstance(self.qtgui_time_sink_x_1.qwidget(), Qt.QWidget)
         self.top_layout.addWidget(self._qtgui_time_sink_x_1_win)
         self.blocks_throttle2_0 = blocks.throttle( gr.sizeof_gr_complex*1, samp_rate, True, 0 if "auto" == "auto" else max( int(float(0.1) * samp_rate) if "auto" == "time" else int(0.1), 1) )
-        self.blocks_file_source_0 = blocks.file_source(gr.sizeof_gr_complex*1, 'path/to/your/adsb/recording', True, (200*samp_rate), 0)
+        self.blocks_file_source_0 = blocks.file_source(gr.sizeof_gr_complex*1, 'path/to/your/adsb/recording', True, 0, 0)
         self.blocks_file_source_0.set_begin_tag(pmt.PMT_NIL)
         self.blocks_complex_to_mag_squared_0 = blocks.complex_to_mag_squared(1)
         self.adsb_framer_0 = adsb.framer(2e6, 0.01)

--- a/examples/AU_adsb_rx_from_file.py
+++ b/examples/AU_adsb_rx_from_file.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#
+# SPDX-License-Identifier: GPL-3.0
+#
+# GNU Radio Python Flow Graph
+# Title: ADS-B Signal Analyzer
+# Author: shoam&iMRUM
+# GNU Radio version: 3.10.9.2
+
+from PyQt5 import Qt
+from gnuradio import qtgui
+from gnuradio import blocks
+import pmt
+from gnuradio import blocks, gr
+from gnuradio import gr
+from gnuradio.filter import firdes
+from gnuradio.fft import window
+import sys
+import signal
+from PyQt5 import Qt
+from argparse import ArgumentParser
+from gnuradio.eng_arg import eng_float, intx
+from gnuradio import eng_notation
+from gnuradio import zeromq
+import gnuradio.adsb as adsb
+import sip
+
+
+
+class AU_adsb_rx_from_file(gr.top_block, Qt.QWidget):
+
+    def __init__(self):
+        gr.top_block.__init__(self, "ADS-B Signal Analyzer", catch_exceptions=True)
+        Qt.QWidget.__init__(self)
+        self.setWindowTitle("ADS-B Signal Analyzer")
+        qtgui.util.check_set_qss()
+        try:
+            self.setWindowIcon(Qt.QIcon.fromTheme('gnuradio-grc'))
+        except BaseException as exc:
+            print(f"Qt GUI: Could not set Icon: {str(exc)}", file=sys.stderr)
+        self.top_scroll_layout = Qt.QVBoxLayout()
+        self.setLayout(self.top_scroll_layout)
+        self.top_scroll = Qt.QScrollArea()
+        self.top_scroll.setFrameStyle(Qt.QFrame.NoFrame)
+        self.top_scroll_layout.addWidget(self.top_scroll)
+        self.top_scroll.setWidgetResizable(True)
+        self.top_widget = Qt.QWidget()
+        self.top_scroll.setWidget(self.top_widget)
+        self.top_layout = Qt.QVBoxLayout(self.top_widget)
+        self.top_grid_layout = Qt.QGridLayout()
+        self.top_layout.addLayout(self.top_grid_layout)
+
+        self.settings = Qt.QSettings("GNU Radio", "AU_adsb_rx_from_file")
+
+        try:
+            geometry = self.settings.value("geometry")
+            if geometry:
+                self.restoreGeometry(geometry)
+        except BaseException as exc:
+            print(f"Qt GUI: Could not restore geometry: {str(exc)}", file=sys.stderr)
+
+        ##################################################
+        # Variables
+        ##################################################
+        self.samp_rate = samp_rate = 2000000
+        self.freq = freq = 1090e6
+
+        ##################################################
+        # Blocks
+        ##################################################
+
+        self.zeromq_pull_msg_source_1 = zeromq.pull_msg_source('tcp://127.0.0.1:9034', 100, False)
+        self.zeromq_pub_msg_sink_0 = zeromq.pub_msg_sink('tcp://127.0.0.1:9034', 100, True)
+        self.qtgui_waterfall_sink_x_0 = qtgui.waterfall_sink_c(
+            1024, #size
+            window.WIN_BLACKMAN_hARRIS, #wintype
+            0, #fc
+            samp_rate, #bw
+            "", #name
+            1, #number of inputs
+            None # parent
+        )
+        self.qtgui_waterfall_sink_x_0.set_update_time(0.10)
+        self.qtgui_waterfall_sink_x_0.enable_grid(False)
+        self.qtgui_waterfall_sink_x_0.enable_axis_labels(True)
+
+
+
+        labels = ['', '', '', '', '',
+                  '', '', '', '', '']
+        colors = [0, 0, 0, 0, 0,
+                  0, 0, 0, 0, 0]
+        alphas = [1.0, 1.0, 1.0, 1.0, 1.0,
+                  1.0, 1.0, 1.0, 1.0, 1.0]
+
+        for i in range(1):
+            if len(labels[i]) == 0:
+                self.qtgui_waterfall_sink_x_0.set_line_label(i, "Data {0}".format(i))
+            else:
+                self.qtgui_waterfall_sink_x_0.set_line_label(i, labels[i])
+            self.qtgui_waterfall_sink_x_0.set_color_map(i, colors[i])
+            self.qtgui_waterfall_sink_x_0.set_line_alpha(i, alphas[i])
+
+        self.qtgui_waterfall_sink_x_0.set_intensity_range(-140, 10)
+
+        self._qtgui_waterfall_sink_x_0_win = sip.wrapinstance(self.qtgui_waterfall_sink_x_0.qwidget(), Qt.QWidget)
+
+        self.top_layout.addWidget(self._qtgui_waterfall_sink_x_0_win)
+        self.qtgui_time_sink_x_1 = qtgui.time_sink_f(
+            1024, #size
+            samp_rate, #samp_rate
+            "", #name
+            1, #number of inputs
+            None # parent
+        )
+        self.qtgui_time_sink_x_1.set_update_time(0.10)
+        self.qtgui_time_sink_x_1.set_y_axis(-1, 1)
+
+        self.qtgui_time_sink_x_1.set_y_label('Signal Strength', 'db')
+
+        self.qtgui_time_sink_x_1.enable_tags(True)
+        self.qtgui_time_sink_x_1.set_trigger_mode(qtgui.TRIG_MODE_FREE, qtgui.TRIG_SLOPE_POS, 0.0, 0, 0, "")
+        self.qtgui_time_sink_x_1.enable_autoscale(True)
+        self.qtgui_time_sink_x_1.enable_grid(True)
+        self.qtgui_time_sink_x_1.enable_axis_labels(True)
+        self.qtgui_time_sink_x_1.enable_control_panel(False)
+        self.qtgui_time_sink_x_1.enable_stem_plot(False)
+
+
+        labels = ['Signal 1', 'Signal 2', 'Signal 3', 'Signal 4', 'Signal 5',
+            'Signal 6', 'Signal 7', 'Signal 8', 'Signal 9', 'Signal 10']
+        widths = [1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1]
+        colors = ['blue', 'red', 'green', 'black', 'cyan',
+            'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+        alphas = [1.0, 1.0, 1.0, 1.0, 1.0,
+            1.0, 1.0, 1.0, 1.0, 1.0]
+        styles = [1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1]
+        markers = [-1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1]
+
+
+        for i in range(1):
+            if len(labels[i]) == 0:
+                self.qtgui_time_sink_x_1.set_line_label(i, "Data {0}".format(i))
+            else:
+                self.qtgui_time_sink_x_1.set_line_label(i, labels[i])
+            self.qtgui_time_sink_x_1.set_line_width(i, widths[i])
+            self.qtgui_time_sink_x_1.set_line_color(i, colors[i])
+            self.qtgui_time_sink_x_1.set_line_style(i, styles[i])
+            self.qtgui_time_sink_x_1.set_line_marker(i, markers[i])
+            self.qtgui_time_sink_x_1.set_line_alpha(i, alphas[i])
+
+        self._qtgui_time_sink_x_1_win = sip.wrapinstance(self.qtgui_time_sink_x_1.qwidget(), Qt.QWidget)
+        self.top_layout.addWidget(self._qtgui_time_sink_x_1_win)
+        self.blocks_throttle2_0 = blocks.throttle( gr.sizeof_gr_complex*1, samp_rate, True, 0 if "auto" == "auto" else max( int(float(0.1) * samp_rate) if "auto" == "time" else int(0.1), 1) )
+        self.blocks_message_debug_0 = blocks.message_debug(True, gr.log_levels.info)
+        self.blocks_file_source_0 = blocks.file_source(gr.sizeof_gr_complex*1, 'path/to/your/adsb/recording', True, (200*samp_rate), 0)
+        self.blocks_file_source_0.set_begin_tag(pmt.PMT_NIL)
+        self.blocks_complex_to_mag_squared_0 = blocks.complex_to_mag_squared(1)
+        self.adsb_framer_0 = adsb.framer(2e6, 0.01)
+        self.adsb_demod_0 = adsb.demod(2e6)
+        self.adsb_decoder_0 = adsb.decoder("Extended Squitter Only", "None", "Verbose")
+
+
+        ##################################################
+        # Connections
+        ##################################################
+        self.msg_connect((self.adsb_decoder_0, 'decoded'), (self.zeromq_pub_msg_sink_0, 'in'))
+        self.msg_connect((self.adsb_demod_0, 'demodulated'), (self.adsb_decoder_0, 'demodulated'))
+        self.msg_connect((self.zeromq_pull_msg_source_1, 'out'), (self.blocks_message_debug_0, 'print'))
+        self.connect((self.adsb_demod_0, 0), (self.qtgui_time_sink_x_1, 0))
+        self.connect((self.adsb_framer_0, 0), (self.adsb_demod_0, 0))
+        self.connect((self.blocks_complex_to_mag_squared_0, 0), (self.adsb_framer_0, 0))
+        self.connect((self.blocks_file_source_0, 0), (self.blocks_throttle2_0, 0))
+        self.connect((self.blocks_throttle2_0, 0), (self.blocks_complex_to_mag_squared_0, 0))
+        self.connect((self.blocks_throttle2_0, 0), (self.qtgui_waterfall_sink_x_0, 0))
+
+
+    def closeEvent(self, event):
+        self.settings = Qt.QSettings("GNU Radio", "AU_adsb_rx_from_file")
+        self.settings.setValue("geometry", self.saveGeometry())
+        self.stop()
+        self.wait()
+
+        event.accept()
+
+    def get_samp_rate(self):
+        return self.samp_rate
+
+    def set_samp_rate(self, samp_rate):
+        self.samp_rate = samp_rate
+        self.blocks_throttle2_0.set_sample_rate(self.samp_rate)
+        self.qtgui_time_sink_x_1.set_samp_rate(self.samp_rate)
+        self.qtgui_waterfall_sink_x_0.set_frequency_range(0, self.samp_rate)
+
+    def get_freq(self):
+        return self.freq
+
+    def set_freq(self, freq):
+        self.freq = freq
+
+
+
+
+def main(top_block_cls=AU_adsb_rx_from_file, options=None):
+
+    qapp = Qt.QApplication(sys.argv)
+
+    tb = top_block_cls()
+
+    tb.start()
+
+    tb.show()
+
+    def sig_handler(sig=None, frame=None):
+        tb.stop()
+        tb.wait()
+
+        Qt.QApplication.quit()
+
+    signal.signal(signal.SIGINT, sig_handler)
+    signal.signal(signal.SIGTERM, sig_handler)
+
+    timer = Qt.QTimer()
+    timer.start(500)
+    timer.timeout.connect(lambda: None)
+
+    qapp.exec_()
+
+if __name__ == '__main__':
+    main()

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -37,7 +37,7 @@
 </head>
 <body>
   <div id="map"></div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.js"></script>
   <script src="./js/leaflet.rotatedMarker.js"></script>
   <script src="./js/map.js"></script>
 </body>


### PR DESCRIPTION
## Changes in this Fork  
  
**Updated GNU Radio Flowgraph**:    
- Replaced UHD USRP Source with SoapySDR RTL-SDR source (Maintained 2M sample rate and 1.09G center frequency)
- Added file source version for offline analysis  
- Added waterfall and time sink displays for signal visualization  
  
**Modifications for RTL2832U Compatibility**:    
- Added SoapySDR API for RTL-SDR hardware access  
- Added configurable gain control with default 20dB setting
  
**Updated Webserver Dependencies**:  
- Upgraded `socket.io` version to **4.8.1** in `index.html` for v4 support  
- Added Python virtual environment instructions  