### PR TITLE
dramatic speed improvements and code cleanup

### DIFF
--- a/python/adsb/decoder.py
+++ b/python/adsb/decoder.py
@@ -330,7 +330,7 @@ class decoder(gr.sync_block):
         meta = pmt.to_python(pmt.car(pdu))
         vector = pmt.to_python(pmt.cdr(pdu))
         self.timestamp = meta["timestamp"]
-        self.datetime = datetime.datetime.utcfromtimestamp(self.timestamp).strftime("%Y-%m-%d %H:%M:%S.%f UTC")
+        self.datetime = datetime.datetime.fromtimestamp(self.timestamp, datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f UTC")
         self.snr = meta["snr"]
         self.bits = vector
 
@@ -352,8 +352,6 @@ class decoder(gr.sync_block):
 
 
     def reset(self):
-        self.aa_bits = []
-        self.aa = -1
         self.aa_str = ""
         self.df = -1
         self.payload_length = -1
@@ -371,43 +369,9 @@ class decoder(gr.sync_block):
             `heading = 180/-180` Westbound
             `heading = -90` Southbound
         """
-        if heading < 0:
-            heading += 360.0
-
-        quad = np.floor(heading/90.0)
-        residual_angle = heading - quad*90.0
-        sub_quad = np.floor((residual_angle+22.5)/45.0)
-
-        if quad == 0:
-            if sub_quad == 0:
-                dir_str = "E"
-            elif sub_quad == 1:
-                dir_str = "NE"
-            else:
-                dir_str = "N"
-        elif quad == 1:
-            if sub_quad == 0:
-                dir_str = "N"
-            elif sub_quad == 1:
-                dir_str = "NW"
-            else:
-                dir_str = "W"
-        elif quad == 2:
-            if sub_quad == 0:
-                dir_str = "W"
-            elif sub_quad == 1:
-                dir_str = "SW"
-            else:
-                dir_str = "S"
-        else:
-            if sub_quad == 0:
-                dir_str = "S"
-            elif sub_quad == 1:
-                dir_str = "SE"
-            else:
-                dir_str = "E"
-
-        return dir_str
+        heading = (float(heading) + 45/2) % 360
+        quad = int(heading / 45)
+        return ("E", "NE", "N", "NW", "W", "SW", "S", "SE")[quad]
 
 
     def update_plane(self, aa_str):
@@ -440,61 +404,60 @@ class decoder(gr.sync_block):
 
 
     def reset_plane_altimetry(self, plane):
-        plane["altitude"] = np.NaN
-        plane["speed"] = np.NaN
-        plane["heading"] = np.NaN
-        plane["vertical_rate"] = np.NaN
-        plane["latitude"] = np.NaN
-        plane["longitude"] = np.NaN
-        plane["cpr"] = [(np.NaN, np.NaN, np.NaN), (np.NaN, np.NaN, np.NaN)]
+        plane["altitude"] = np.nan
+        plane["speed"] = np.nan
+        plane["heading"] = np.nan
+        plane["vertical_rate"] = np.nan
+        plane["latitude"] = np.nan
+        plane["longitude"] = np.nan
+        plane["cpr"] = [(np.nan, np.nan, np.nan), (np.nan, np.nan, np.nan)]
 
 
     def print_planes(self):
-        index = 0
-        for icao in self.plane_dict:
-            last_seen = datetime.datetime.utcfromtimestamp(self.timestamp).strftime("%H:%M:%S")
+        for index, icao in enumerate(self.plane_dict, start=2):
+            last_seen = datetime.datetime.fromtimestamp(self.plane_dict[icao]["last_seen"], datetime.timezone.utc).strftime("%H:%M:%S")
 
             if self.plane_dict[icao]["callsign"] is not None:
-                callsign = "{:8s}".format(self.plane_dict[icao]["callsign"])
+                callsign = f"{self.plane_dict[icao]["callsign"]:8s}"
             else:
                 callsign = " "*8
 
-            if np.isnan(self.plane_dict[icao]["altitude"]) == False:
-                altitude = "{:5.0f}".format(self.plane_dict[icao]["altitude"])
-            else:
+            if np.isnan(self.plane_dict[icao]["altitude"]):
                 altitude = " "*5
-
-            if np.isnan(self.plane_dict[icao]["vertical_rate"]) == False:
-                vertical_rate = "{:5.0f}".format(self.plane_dict[icao]["vertical_rate"])
             else:
+                altitude = f'{self.plane_dict[icao]["altitude"]:5.0f}'
+
+            if np.isnan(self.plane_dict[icao]["vertical_rate"]):
                 vertical_rate = " "*5
-
-            if np.isnan(self.plane_dict[icao]["speed"]) == False:
-                speed = "{:5.0f}".format(self.plane_dict[icao]["speed"])
             else:
+                vertical_rate = f'{self.plane_dict[icao]["vertical_rate"]:5.0f}'
+
+            if np.isnan(self.plane_dict[icao]["speed"]):
                 speed = " "*5
-
-            if np.isnan(self.plane_dict[icao]["heading"]) == False:
-                heading = "{:5.0f}".format(self.plane_dict[icao]["heading"])
             else:
+                speed = f'{self.plane_dict[icao]["speed"]:5.0f}'
+
+            if np.isnan(self.plane_dict[icao]["heading"]):
                 heading = " "*5
-
-            if np.isnan(self.plane_dict[icao]["latitude"]) == False:
-                latitude = "{:11.7f}".format(self.plane_dict[icao]["latitude"])
             else:
+                heading = f'{self.plane_dict[icao]["heading"]:5.0f}'
+
+            if np.isnan(self.plane_dict[icao]["latitude"]):
                 latitude = " "*11
-
-            if np.isnan(self.plane_dict[icao]["longitude"]) == False:
-                longitude = "{:11.7f}".format(self.plane_dict[icao]["longitude"])
             else:
+                latitude = f'{self.plane_dict[icao]["latitude"]:11.7f}'
+
+            if np.isnan(self.plane_dict[icao]["longitude"]):
                 longitude = " "*11
+            else:
+                longitude = f'{self.plane_dict[icao]["longitude"]:11.7f}'
 
-            num_msgs = "{:4d}".format(self.plane_dict[icao]["num_msgs"])
-            age = "{:3.0f}".format(int(time.time()) - self.plane_dict[icao]["last_seen"])
+            num_msgs = f'{self.plane_dict[icao]["num_msgs"]:4d}'
+            age = f'{int(time.time()) - self.plane_dict[icao]["last_seen"]:3.0f}'
 
-            self.screen.addstr(2 + index, 0, "{:8s} {:6s} {} {} {} {} {} {} {} {}".format(
-                last_seen,
-                icao,
+            self.screen.addstr(index, 0, " ".join((
+                last_seen[:8],
+                icao[:6],
                 callsign,
                 altitude,
                 vertical_rate,
@@ -503,10 +466,8 @@ class decoder(gr.sync_block):
                 latitude,
                 longitude,
                 num_msgs
-            ))
-            self.screen.refresh()
-
-            index += 1
+            )))
+        self.screen.refresh()
 
 
     def publish_decoded_pdu(self, aa_str):
@@ -585,9 +546,9 @@ class decoder(gr.sync_block):
 
                 # XOR the computed CRC with the AP, the result should be the
                 # interrogated plane's ICAO address
-                self.aa_bits = crc_bits ^ ap_bits
-                self.aa = self.bin2dec(self.aa_bits)
-                self.aa_str = "{:06x}".format(self.aa)
+                aa_bits = crc_bits ^ ap_bits
+                aa = self.bin2dec(aa_bits)
+                self.aa_str = f"{aa:06x}"
 
                 # If the ICAO address is in our plane dictionary,
                 # then it's safe to assume the CRC passes
@@ -603,7 +564,7 @@ class decoder(gr.sync_block):
                     self.log("info", "Address Announced (AA)", self.aa_str)
                     return 0
 
-            elif self.df in [11]:
+            elif self.df == 11:
                 # 56 bit payload
                 self.payload_length = 56
 
@@ -646,9 +607,9 @@ class decoder(gr.sync_block):
 
                 # XOR the computed CRC with the AP, the result should be the
                 # interrogated plane's ICAO address
-                self.aa_bits = crc_bits ^ ap_bits
-                self.aa = self.bin2dec(self.aa_bits)
-                self.aa_str = "{:06x}".format(self.aa)
+                aa_bits = crc_bits ^ ap_bits
+                aa = self.bin2dec(aa_bits)
+                self.aa_str = "{:06x}".format(aa)
 
                 # If the ICAO address is in our plane dictionary,
                 # then it's safe to assume the CRC passes
@@ -884,9 +845,9 @@ class decoder(gr.sync_block):
                 ca = self.bin2dec(self.bits[5:5+3])
 
                 # Address Announced (ICAO Address) 24 bits
-                self.aa_bits = self.bits[8:8+24]
-                self.aa = self.bin2dec(self.aa_bits)
-                self.aa_str = "{:06x}".format(self.aa)
+                aa_bits = self.bits[8:8+24]
+                aa = self.bin2dec(aa_bits)
+                self.aa_str = "{:06x}".format(aa)
 
                 # Update planes dictionary
                 self.update_plane(self.aa_str)
@@ -903,9 +864,9 @@ class decoder(gr.sync_block):
                 self.log("info", "Capability (CA)", ca, subvalue=CA_STR_LUT[ca])
 
                 # Address Announced (ICAO Address) 24 bits
-                self.aa_bits = self.bits[8:8+24]
-                self.aa = self.bin2dec(self.aa_bits)
-                self.aa_str = "{:06x}".format(self.aa)
+                aa_bits = self.bits[8:8+24]
+                aa = self.bin2dec(aa_bits)
+                self.aa_str = "{:06x}".format(aa)
                 self.log("info", "Address Announced (AA)", self.aa_str)
                 self.log("info", "Callsign", self.plane_dict.get(self.aa_str, {}).get("callsign", ""))
 
@@ -919,9 +880,9 @@ class decoder(gr.sync_block):
                 self.log("info", "CF", cf, CF_STR_LUT[cf])
 
                 # Address Announced (ICAO Address) 24 bits
-                self.aa_bits = self.bits[8:8+24]
-                self.aa = self.bin2dec(self.aa_bits)
-                self.aa_str = "{:06x}".format(self.aa)
+                aa_bits = self.bits[8:8+24]
+                aa = self.bin2dec(aa_bits)
+                self.aa_str = "{:06x}".format(aa)
                 self.log("info", "Address Announced (AA)", self.aa_str)
                 self.log("info", "Callsign", self.plane_dict.get(self.aa_str, {}).get("callsign", ""))
 
@@ -933,9 +894,9 @@ class decoder(gr.sync_block):
                     self.decode_me()
                 elif cf in [2,3,5]:
                     self.decode_tisb_me()
-                elif cf in [4]:
+                elif cf == 4:
                     self.log("debug", "TIS-B and ADS-B Management Message", "To be implemented")
-                elif cf in [6]:
+                elif cf == 6:
                     self.log("debug", "ADS-B Message Rebroadcast", "To be implemented")
 
             # Military Extended Squitter
@@ -945,14 +906,14 @@ class decoder(gr.sync_block):
                 self.log("info", "Application Field (AF)", af, AF_STR_LUT[af])
 
                 # Address Announced (ICAO Address) 24 bits
-                self.aa_bits = self.bits[8:8+24]
-                self.aa = self.bin2dec(self.aa_bits)
-                self.aa_str = "{:06x}".format(self.aa)
+                aa_bits = self.bits[8:8+24]
+                aa = self.bin2dec(aa_bits)
+                self.aa_str = "{:06x}".format(aa)
                 self.log("info", "Address Announced (AA)", self.aa_str)
                 self.log("info", "Callsign", self.plane_dict.get(self.aa_str, {}).get("callsign", ""))
                 self.log("debug", "DF={} AF={}".format(self.df, af), "Spotted in the wild!")
 
-                if af in [0]:
+                if af == 0:
                     self.decode_me()
                 elif af in [1,2,3,4,5,6,7]:
                     self.log("debug", "AF={}".format(af), "Reserved for Military Use")
@@ -1066,12 +1027,12 @@ class decoder(gr.sync_block):
         self.log("info", "Type Code (TC)", tc, TC_STR_LUT[tc])
 
         ## Airborne/Surface Position ###
-        if tc in [0]:
+        if tc == 0:
             # Message, 3 bits
             me = self.bits[0:self.payload_length]
 
         ### Aircraft Identification ###
-        elif tc in range(1,5):
+        elif 1 <= tc < 5:
             # Grab callsign using character LUT
             callsign = ""
 
@@ -1091,12 +1052,12 @@ class decoder(gr.sync_block):
             # print("Callsign: {}".format(callsign))
 
         ### Surface Position ###
-        elif tc in range(5,9):
+        elif tc < 9:
             self.log("debug", "TC", tc, "To be implemented")
             self.publish_unknown_pdu()
 
         ### Airborne Position (Baro Altitude) ###
-        elif tc in range(9,19):
+        elif tc < 19:
             # Surveillance Status, 2 bits
             ss = self.bin2dec(self.bits[37:37+2])
 
@@ -1154,7 +1115,7 @@ class decoder(gr.sync_block):
 
 
         ### Airborne Velocities ###
-        elif tc in [19]:
+        elif tc == 19:
             # Sub Type, 3 bits
             st = self.bin2dec(self.bits[37:37+3])
 
@@ -1256,42 +1217,42 @@ class decoder(gr.sync_block):
                 self.log("debug", "DF={} TC={} ST={}".format(self.df, tc, self.st), "To be implemented")
 
         ### Airborne Position (GNSS Height) ###
-        elif tc in range(20,23):
+        elif tc < 23:
             self.log("debug", "TC", tc, "To be implemented")
             self.publish_unknown_pdu()
 
         ### Test Message ###
-        elif tc in [23]:
+        elif tc == 23:
             self.log("debug", "TC", tc, "To be implemented")
             self.publish_unknown_pdu()
 
         ### Surface System Status ###
-        elif tc in [24]:
+        elif tc == 24:
             self.log("debug", "TC", tc, "To be implemented")
             self.publish_unknown_pdu()
 
         ### Reserved ###
-        elif tc in range(25,28):
+        elif 25 <= tc < 28:
             self.log("debug", "TC", tc, "To be implemented")
             self.publish_unknown_pdu()
 
         ### Extended Squitter A/C Status ###
-        elif tc in [28]:
+        elif tc == 28:
             self.log("debug", "TC", tc, "To be implemented")
             self.publish_unknown_pdu()
 
         ### Target State and Status (V.2) ###
-        elif tc in [29]:
+        elif tc == 29:
             self.log("debug", "TC", tc, "To be implemented")
             self.publish_unknown_pdu()
 
         ### Reserved ###
-        elif tc in [30]:
+        elif tc == 30:
             self.log("debug", "TC", tc, "To be implemented")
             self.publish_unknown_pdu()
 
         ### Aircraft Operation Status ###
-        elif tc in [31]:
+        elif tc == 31:
             self.log("debug", "TC", tc, "To be implemented")
             self.publish_unknown_pdu()
 
@@ -1309,8 +1270,8 @@ class decoder(gr.sync_block):
     def calculate_lat_lon(self, cpr):
         # If the even and odd frame data is still valid, calculate the
         # latitude and longitude
-        lat_dec = np.NaN
-        lon_dec = np.NaN
+        lat_dec = np.nan
+        lon_dec = np.nan
 
         if (int(time.time()) - cpr[0][2]) < CPR_TIMEOUT_S and (int(time.time()) - cpr[1][2]) < CPR_TIMEOUT_S:
             # Get fractional lat/lon for the even and odd frame
@@ -1374,7 +1335,7 @@ class decoder(gr.sync_block):
     def cpr_n(self, lat, frame):
         # frame = 0, even frame
         # frame = 1, odd frame
-        n = self.cpr_nl(lat) - frame;
+        n = self.cpr_nl(lat) - frame
 
         if n > 1:
             return n

--- a/python/adsb/demod.py
+++ b/python/adsb/demod.py
@@ -43,12 +43,7 @@ class demod(gr.sync_block):
         self.sps = int(fs // SYMBOL_RATE)
 
         # Calculate current UTC time at block startup. Then we'll use burst sample offset to derive burst time.
-        self.start_timestamp = (datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)).total_seconds()
-
-        # Array of data bits
-        self.bits = []
-        self.bit_idx = 0
-        self.straddled_packet = 0
+        self.start_timestamp = datetime.datetime.now(datetime.timezone.utc).timestamp()
 
         self.set_tag_propagation_policy(gr.TPP_ONE_TO_ONE)
         self.message_port_register_out(pmt.to_pmt("demodulated"))
@@ -57,11 +52,6 @@ class demod(gr.sync_block):
     def work(self, input_items, output_items):
         in0 = input_items[0]
         out0 = output_items[0]
-
-        # If there was a packet that straddled the previous block and this
-        # block, finish decoding it
-        if self.straddled_packet == 1:
-            self.straddled_packet = 0
 
         # Get tags from ADS-B Framer block
         tags = self.get_tags_in_range(0, self.nitems_read(0), self.nitems_read(0) + len(in0), pmt.to_pmt("burst"))
@@ -73,7 +63,7 @@ class demod(gr.sync_block):
 
             # Calculate the SOB and EOB offsets
             sob_offset = tag.offset + (8)*self.sps # Start of burst index (middle of the "bit 1 pulse")
-            eob_offset = tag.offset + (8+112-1)*self.sps + self.sps/2 # End of burst index (middle of the "bit 0 pulse")
+            eob_offset = tag.offset + (8+MAX_NUM_BITS-1)*self.sps + self.sps/2 # End of burst index (middle of the "bit 0 pulse")
 
             # Find the SOB and EOB indices in this block of samples
             sob_idx = sob_offset - self.nitems_written(0)
@@ -84,54 +74,45 @@ class demod(gr.sync_block):
                 # the entire burst
 
                 # Grab the amplitudes where the "bit 1 pulse" should be
-                bit1_idxs = range(sob_idx, sob_idx + self.sps*MAX_NUM_BITS, self.sps)
-                bit1_amps = in0[bit1_idxs]
+                bit1_amps = in0[sob_idx:sob_idx + self.sps*MAX_NUM_BITS:self.sps]
 
                 # Grab the amplitudes where the "bit 0 pulse" should be
-                bit0_idxs = range(sob_idx + self.sps // 2, sob_idx + self.sps // 2 + self.sps*MAX_NUM_BITS, self.sps)
-                bit0_amps = in0[bit0_idxs]
-
-                self.bits = np.zeros(MAX_NUM_BITS, dtype=np.uint8)
-                self.bits[bit1_amps > bit0_amps] = 1
-
-                # Get a log-likelihood type function for probability of a
-                # bit being a 0 or 1.  Confidence of 0 is equally likely 0 or 1.
-                # Positive confidence levels are more likely 1 and negative values
-                # are more likely 0.
-                with np.errstate(divide='ignore'):
-                    self.bit_confidence = 10.0*(np.log10(bit1_amps)-np.log10(bit0_amps))
+                bit0_amps = in0[sob_idx + self.sps // 2:sob_idx + self.sps // 2 + self.sps*MAX_NUM_BITS:self.sps]
+                bits = np.zeros(MAX_NUM_BITS, dtype=np.uint8)
+                bits[bit1_amps > bit0_amps] = 1
 
                 # Send PDU message to decoder
                 meta = pmt.to_pmt({
                     "timestamp": self.start_timestamp + tag.offset/self.fs,
                     "snr": snr,
                 })
-                vector = pmt.to_pmt(self.bits)
+                vector = pmt.to_pmt(bits)
                 pdu = pmt.cons(meta, vector)
                 self.message_port_pub(pmt.to_pmt("demodulated"), pdu)
 
                 if False:
+                    # Get a log-likelihood type function for probability of a
+                    # bit being a 0 or 1.  Confidence of 0 is equally likely 0 or 1.
+                    # Positive confidence levels are more likely 1 and negative values
+                    # are more likely 0.
+                    with np.errstate(divide='ignore'):
+                        bit_confidence = 10.0*(np.log10(bit1_amps / bit0_amps))
                     # Tag the 0 and 1 bits markers for debug
                     for ii in range(0,len(bit1_idxs)):
                         self.add_item_tag(
                             0,
                             self.nitems_written(0)+bit1_idxs[ii],
                             pmt.to_pmt("bits"),
-                            pmt.to_pmt((1, ii, float(self.bit_confidence[ii]))),
+                            pmt.to_pmt((1, ii, float(bit_confidence[ii]))),
                             pmt.to_pmt("demod")
                         )
                         self.add_item_tag(
                             0,
                             self.nitems_written(0)+bit0_idxs[ii],
                             pmt.to_pmt("bits"),
-                            pmt.to_pmt((0, ii, float(self.bit_confidence[ii]))),
+                            pmt.to_pmt((0, ii, float(bit_confidence[ii]))),
                             pmt.to_pmt("demod")
                         )
-
-            else:
-                # The packet is only partially contained in this block of
-                # samples, decode as much as possible
-                self.straddled_packet = 1
 
         out0[:] = in0
         return len(output_items[0])

--- a/python/adsb/framer.py
+++ b/python/adsb/framer.py
@@ -47,7 +47,7 @@ class framer(gr.sync_block):
 
         # Initialize the preamble "pulses" template
         # This is 2*fsym or 2 Msps, i.e. there are 2 pulses per symbol
-        self.preamble_pulses = [1,0,1,0,0,0,0,1,0,1,0,0,0,0,0,0]
+        self.preamble_pulses = np.array([1,0,1,0,0,0,0,1,0,1,0,0,0,0,0,0], dtype=np.bool)
 
         # Last sample from previous work() call.  Needed for finding pulses at
         # the beginning of the current work() call.

--- a/python/adsb/framer.py
+++ b/python/adsb/framer.py
@@ -80,8 +80,7 @@ class framer(gr.sync_block):
         # the threshold value. 1 = above threshold, 0 = below threshold
         # NOTE: Add the last sample from the previous work() call to the
         # beginning of this block of samples
-        in0_pulses = np.zeros(N+1, dtype=int)
-        in0_pulses[np.insert(in0[0:N], 0, self.prev_in0) >= self.threshold] = 1
+        in0_pulses = (np.insert(in0[0:N], 0, self.prev_in0) >= self.threshold).view(np.int8)
 
         # Set prev_in0 for the next work() call
         self.prev_in0 = in0[N-1]
@@ -89,10 +88,10 @@ class framer(gr.sync_block):
         # Subtract the previous pulse from the current pulse to get transitions
         # +1 = rising edge, -1 = falling edge
         in0_transitions = in0_pulses[1:] - in0_pulses[:-1]
-        in0_rise_edge_idxs = np.nonzero(in0_transitions == 1)[0]
-        in0_fall_edge_idxs = np.nonzero(in0_transitions == -1)[0]
+        in0_rise_edge_idxs = np.flatnonzero(in0_transitions == 1)
+        in0_fall_edge_idxs = np.flatnonzero(in0_transitions == -1)
 
-        if len(in0_rise_edge_idxs) > 0 and len(in0_fall_edge_idxs) > 0:
+        if len(in0_rise_edge_idxs) and len(in0_fall_edge_idxs):
             # Make sure the first sample for the rising and falling edge indices corresponds
             # to the same pulse
             if in0_fall_edge_idxs[0] - in0_rise_edge_idxs[0] < 0:
@@ -137,14 +136,10 @@ class framer(gr.sync_block):
                     amps = in0[pulse_idx:pulse_idx + NUM_PREAMBLE_BITS*self.sps:self.sps // 2]
 
                     # Set a pulse to 1 if it's greater than 1/2 the amplitude of the detected pulse
-                    pulses = np.zeros(NUM_PREAMBLE_PULSES, dtype=int)
-                    pulses[amps > in0[pulse_idx]/2] = 1
-
-                    # Count how many "pulses" or half symbols match the preamble "pulses"
-                    corr_matches = np.sum(pulses == self.preamble_pulses)
+                    pulses = amps > in0[pulse_idx]/2
 
                     # Only assert preamble found if all the 1/2 symbols match
-                    if corr_matches == NUM_PREAMBLE_PULSES:
+                    if np.array_equal(pulses, self.preamble_pulses):
                         # Found a preamble correlation
 
                         # Calculate burst SNR
@@ -169,7 +164,7 @@ class framer(gr.sync_block):
                             0,
                             (self.nitems_written(0) - (self.N_hist-1)) + pulse_idx,
                             pmt.to_pmt("burst"),
-                            pmt.to_pmt(("SOB", snr)),
+                            pmt.to_pmt(("SOB", float(snr))),
                             pmt.to_pmt("framer")
                         )
 

--- a/python/adsb/framer.py
+++ b/python/adsb/framer.py
@@ -47,7 +47,7 @@ class framer(gr.sync_block):
 
         # Initialize the preamble "pulses" template
         # This is 2*fsym or 2 Msps, i.e. there are 2 pulses per symbol
-        self.preamble_pulses = np.array([1,0,1,0,0,0,0,1,0,1,0,0,0,0,0,0], dtype=np.bool)
+        self.preamble_pulses = np.array([1,0,1,0,0,0,0,1,0,1,0,0,0,0,0,0], dtype=bool)
 
         # Last sample from previous work() call.  Needed for finding pulses at
         # the beginning of the current work() call.

--- a/python/adsb/framer.py
+++ b/python/adsb/framer.py
@@ -51,10 +51,10 @@ class framer(gr.sync_block):
 
         # Last sample from previous work() call.  Needed for finding pulses at
         # the beginning of the current work() call.
-        self.prev_in0 = 0
+        self.prev_in0:float = 0
 
         # End of the last burst (56 bit message).  Don"t look for preambles during a valid packet
-        self.prev_eob_idx = -1
+        self.prev_eob_idx:int = -1
 
         # Set history so we can check for a preambles that wrapped around the
         # end of the previous work() call's input_items[0]
@@ -85,31 +85,18 @@ class framer(gr.sync_block):
         # Set prev_in0 for the next work() call
         self.prev_in0 = in0[N-1]
 
-        # Subtract the previous pulse from the current pulse to get transitions
-        # +1 = rising edge, -1 = falling edge
-        in0_transitions = in0_pulses[1:] - in0_pulses[:-1]
-        in0_rise_edge_idxs = np.flatnonzero(in0_transitions == 1)
-        in0_fall_edge_idxs = np.flatnonzero(in0_transitions == -1)
-
-        if len(in0_rise_edge_idxs) and len(in0_fall_edge_idxs):
-            # Make sure the first sample for the rising and falling edge indices corresponds
-            # to the same pulse
-            if in0_fall_edge_idxs[0] - in0_rise_edge_idxs[0] < 0:
-                # The first falling edge comes before the first rising edge, so remove it
-                in0_fall_edge_idxs = np.delete(in0_fall_edge_idxs, 0)
-
-            if len(in0_rise_edge_idxs) > len(in0_fall_edge_idxs):
-                # If there are more rising edges than falling edges, then
-                # remove the extras
-                # NOTE: There technically can only possibly be 1 extra rising edge, if
-                # there are more, something went terribly wrong
-                if len(in0_rise_edge_idxs) - len(in0_fall_edge_idxs) == 1:
-                    in0_rise_edge_idxs = np.delete(in0_rise_edge_idxs, len(in0_rise_edge_idxs) - 1)
-                else:
-                    print("Oh no, this shouldn't be happening...")
+        # transitions will always come in pairs (minus edge cases dealt with later) so just go through the array once
+        # this is for whatever reason the fastest combination of these two lines of code. Combining them into one slows things down.
+        in0_transitions = in0_pulses[1:] ^ in0_pulses[:-1]
+        trans_indxs = np.where(in0_transitions == 1)[0]
+        if len(trans_indxs) > 2:
+            start_idx = in0_pulses[trans_indxs[0]] # if the first pulse is a 1, that means it was a falling edge first, so move us to the next transition
+            # either rise,fall is 0,1 or 1,2
+            in0_fall_edge_idxs = trans_indxs[start_idx + 1::2]
+            in0_rise_edge_idxs = trans_indxs[start_idx:len(in0_fall_edge_idxs)*2:2]
 
             # Find the index of the center of each pulses
-            pulse_idxs = np.mean((in0_fall_edge_idxs, in0_rise_edge_idxs), axis=0, dtype=int)
+            pulse_idxs = np.mean((in0_fall_edge_idxs, in0_rise_edge_idxs), axis=0, dtype=in0_fall_edge_idxs.dtype)
 
             # For each pulse found, check if that pulse is the beginning of the ADS-B
             # preamble.


### PR DESCRIPTION
Mostly things I noticed in #68. Includes some things that were needed to run on a modern Debian Trixie system, including converting to float before going into the PMT and fixing deprecated functionality like nan and datetime utc functions.

I recorded a file off my RTL_SDR of the mag^2 such that the the only blocks are the file source and blocks from this repo. 
<details>

<summary>Test compiled flowgraph</summary>

```Python
#!/usr/bin/env python3
# -*- coding: utf-8 -*-

#
# SPDX-License-Identifier: GPL-3.0
#
# GNU Radio Python Flow Graph
# Title: ADS-B Receiver
# Author: Matt Hostetter
# GNU Radio version: 3.10.9.2

from gnuradio import blocks
import pmt
from gnuradio import gr
from gnuradio.filter import firdes
from gnuradio.fft import window
import sys
import signal
from argparse import ArgumentParser
from gnuradio.eng_arg import eng_float, intx
from gnuradio import eng_notation
import gnuradio.adsb as adsb




class adsb_rx(gr.top_block):

    def __init__(self):
        gr.top_block.__init__(self, "ADS-B Receiver", catch_exceptions=True)

        ##################################################
        # Variables
        ##################################################
        self.threshold = threshold = 0.1
        self.fs = fs = 2e6
        self.fc = fc = 1090e6

        ##################################################
        # Blocks
        ##################################################

        self.blocks_null_sink_0 = blocks.null_sink(gr.sizeof_float*1)
        self.blocks_file_source_0 = blocks.file_source(gr.sizeof_float*1, 'mags.bin', False, 0, 0)
        self.blocks_file_source_0.set_begin_tag(pmt.PMT_NIL)
        self.adsb_framer_1 = adsb.framer(fs, threshold)
        self.adsb_demod_0 = adsb.demod(fs)
        self.adsb_decoder_0 = adsb.decoder("Extended Squitter Only", "None", "Brief")


        ##################################################
        # Connections
        ##################################################
        self.msg_connect((self.adsb_demod_0, 'demodulated'), (self.adsb_decoder_0, 'demodulated'))
        self.connect((self.adsb_demod_0, 0), (self.blocks_null_sink_0, 0))
        self.connect((self.adsb_framer_1, 0), (self.adsb_demod_0, 0))
        self.connect((self.blocks_file_source_0, 0), (self.adsb_framer_1, 0))


    def get_threshold(self):
        return self.threshold

    def set_threshold(self, threshold):
        self.threshold = threshold
        self.adsb_framer_1.set_threshold(self.threshold)

    def get_fs(self):
        return self.fs

    def set_fs(self, fs):
        self.fs = fs

    def get_fc(self):
        return self.fc

    def set_fc(self, fc):
        self.fc = fc




def main(top_block_cls=adsb_rx, options=None):
    tb = top_block_cls()

    def sig_handler(sig=None, frame=None):
        tb.stop()
        tb.wait()

        sys.exit(0)

    signal.signal(signal.SIGINT, sig_handler)
    signal.signal(signal.SIGTERM, sig_handler)

    tb.start()

    tb.wait()


if __name__ == '__main__':
    main()
```
</details>

The file is ~1 GB at 2 Msps, so ~ 2 ish minutes. Within that time period I saw a few dozen messages. Not as many as I'd like, but it's something. Running the existing code (+ the nan and PMT float change to get it to at least run) I see:

```$ hyperfine ./adsb_rx.py --output=pipe
Benchmark 1: ./adsb_rx.py
  Time (mean ± σ):     60.484 s ±  0.716 s    [User: 31.072 s, System: 34.338 s]
  Range (min … max):   59.325 s … 61.327 s    10 runs
```

With my code:

```$ hyperfine ./adsb_rx.py --output=pipe
Benchmark 1: ./adsb_rx.py
  Time (mean ± σ):     47.305 s ±  0.677 s    [User: 25.369 s, System: 25.957 s]
  Range (min … max):   45.964 s … 48.438 s    10 runs
```

I did not have the file stored in a ramdisk or anything, but I had run it a few times so any caching should be the same for both. I also did my best to not be doing anything else on the computer at the same time. There were a few temporary microbenchmarks run for prove-outs of what was faster vs slower.

I tried to not change functionality but in my opinion the timestamping in the output table was incorrect. It should show the last time the aircraft was seen, not be the same time for all rows. Likewise, I left the `if False`s, because I know that while yes if you know the code was there you can go back in the git history, but sometimes it's nice for debug to just turn them on. However, at least one case there was compute being done that was only used in an `if False` so I just moved that in. On the same lines, there were a decent amount of times that variables were being assigned to the instance but only used within the same function, such as `aa` and `aa_bits`, and a few times the `__init__` dealt with variables that were no longer around.

I caught one semicolon, so I don't know exactly where this code all came from, but I also tried to make it a bit more pythonic. There's certainly some python-isms that reduce performance (such as enums vs string comparison) that seemed out of scope and the goal is to speed things up.

Cloc reports:

Language|files|blank|comment|code
:-------|-------:|-------:|-------:|-------:
Existing|3|317|409|1105
This dev effort|3|307|403|1058


Considering this is ~80% the compute time and gets rid of 50 lines of code (less code means less maintenance, higher readability, etc etc), I think it's worthwhile to be investigated by the powers that be. I didn't see much in the way of tests, but I am willing to attempt getting a reproducible run between the two to make sure they decode everything identically. 